### PR TITLE
Enforce one journal entry per date per user with backend upsert

### DIFF
--- a/packages/express-backend/backend.js
+++ b/packages/express-backend/backend.js
@@ -85,6 +85,35 @@ app.get("/entries", authenticateUser, async (req, res) => {
   }
 });
 
+// GET /entries/by-date/:date
+app.get(
+  "/entries/by-date/:date",
+  authenticateUser,
+  async (req, res) => {
+    try {
+      const owner = req.user.username;
+      const { date } = req.params;
+
+      const entry =
+        await journalService.getEntryByDateForOwner(
+          date,
+          owner
+        );
+
+      if (!entry) {
+        return res.status(200).json({ entry: null });
+      }
+
+      return res.status(200).json({ entry });
+    } catch (error) {
+      console.error("GET /entries/by-date/:date error:", error);
+      return res
+        .status(500)
+        .send("An error occurred in the server.");
+    }
+  }
+);
+
 // POST /entries
 app.post("/entries", authenticateUser, async (req, res) => {
   try {
@@ -93,19 +122,21 @@ app.post("/entries", authenticateUser, async (req, res) => {
     console.log("body:", req.body);
 
     const { title, body, date } = req.body ?? {};
-    if (!title || !body || !date)
+    if (!title || !body || !date) {
       return res
         .status(400)
         .send("title and body and date are required.");
+    }
 
     const owner = req.user.username;
-    const saved = await journalService.createEntry({
+    const saved = await journalService.upsertEntryByDateForOwner({
       title,
       body,
       date,
-      owner //attach journal to specific user
+      owner
     });
-    res.status(201).json(saved);
+
+    res.status(200).json(saved);
   } catch (error) {
     console.error("POST /entries error:", error);
     console.error(error?.stack);
@@ -113,13 +144,17 @@ app.post("/entries", authenticateUser, async (req, res) => {
   }
 });
 
+
 app.get("/entries/:id", authenticateUser, async (req, res) => {
   try {
     const { id } = req.params;
-    const entry = await journalService.deleteEntryByIdForOwner(
+    const owner = req.user.username;
+
+    const entry = await journalService.getEntryByIdForOwner(
       id,
       owner
     );
+
     if (!entry) return res.status(404).send("Entry not found.");
     return res.status(200).json(entry);
   } catch (error) {

--- a/packages/express-backend/models/journal-entry.js
+++ b/packages/express-backend/models/journal-entry.js
@@ -5,10 +5,13 @@ const journalEntrySchema = new mongoose.Schema(
     title: { type: String, required: true, trim: true },
     body: { type: String, required: true },
     date: { type: Date, required: true },
+    dateKey: { type: String, required: true },
     owner: { type: String, required: true }
   },
   { timestamps: true }
 );
+
+journalEntrySchema.index({ owner: 1, dateKey: 1 }, { unique: true });
 
 export default mongoose.model(
   "JournalEntry",

--- a/packages/express-backend/services/journal-service.js
+++ b/packages/express-backend/services/journal-service.js
@@ -1,12 +1,53 @@
 import JournalEntry from "../models/journal-entry.js";
 
-export async function createEntry({
+function normalizeDateKey(inputDate) {
+  if (!inputDate) {
+    throw new Error("date is required");
+  }
+
+  if (typeof inputDate === "string") {
+    return inputDate.slice(0, 10);
+  }
+
+  const d = new Date(inputDate);
+  if (Number.isNaN(d.getTime())) {
+    throw new Error("invalid date");
+  }
+
+  const yyyy = d.getUTCFullYear();
+  const mm = String(d.getUTCMonth() + 1).padStart(2, "0");
+  const dd = String(d.getUTCDate()).padStart(2, "0");
+  return `${yyyy}-${mm}-${dd}`;
+}
+
+function dateFromDateKey(dateKey) {
+  return new Date(`${dateKey}T12:00:00.000Z`);
+}
+
+export async function upsertEntryByDateForOwner({
   title,
   body,
   date,
   owner
 }) {
-  return JournalEntry.create({ title, body, date, owner });
+  const dateKey = normalizeDateKey(date);
+
+  return JournalEntry.findOneAndUpdate(
+    { owner, dateKey },
+    {
+      title,
+      body,
+      owner,
+      dateKey,
+      date: dateFromDateKey(dateKey)
+    },
+    {
+      new: true,
+      upsert: true,
+      runValidators: true,
+      setDefaultsOnInsert: true
+    }
+  );
 }
 
 export async function getEntriesByOwner(owner) {
@@ -25,6 +66,11 @@ export async function getEntryByIdForOwner(id, owner) {
   return JournalEntry.findOne({ _id: id, owner });
 }
 
+export async function getEntryByDateForOwner(date, owner) {
+  const dateKey = normalizeDateKey(date);
+  return JournalEntry.findOne({ owner, dateKey });
+}
+
 export async function deleteEntryByIdForOwner(id, owner) {
   return JournalEntry.findOneAndDelete({ _id: id, owner });
 }
@@ -38,7 +84,12 @@ export async function updateEntryByIdForOwner(
   if (updates.title !== undefined)
     allowed.title = updates.title;
   if (updates.body !== undefined) allowed.body = updates.body;
-  if (updates.date !== undefined) allowed.date = updates.date;
+
+  if (updates.date !== undefined) {
+    const dateKey = normalizeDateKey(updates.date);
+    allowed.dateKey = dateKey;
+    allowed.date = dateFromDateKey(dateKey);
+  }
 
   return JournalEntry.findOneAndUpdate(
     { _id: id, owner },

--- a/packages/react-frontend/src/MyApp.jsx
+++ b/packages/react-frontend/src/MyApp.jsx
@@ -65,17 +65,34 @@ function MyApp() {
 
   function updateList(entry) {
     postEntry(entry)
-      .then((res) => {
-        if (res.status === 201) return res.json();
+      .then(async (res) => {
+        if (!res.ok) {
+          throw new Error(await res.text());
+        }
+        return res.json();
       })
       .then((json) => {
-        setEntries((prevEntries) =>
-          [...prevEntries, json].sort(
+        setEntries((prevEntries) => {
+          const existingIndex = prevEntries.findIndex(
+            (e) => e._id === json._id
+          );
+
+          if (existingIndex !== -1) {
+            const updatedEntries = [...prevEntries];
+            updatedEntries[existingIndex] = json;
+            return updatedEntries.sort(
+              (a, b) =>
+                new Date(b.date || b.createdAt) -
+                new Date(a.date || a.createdAt)
+            );
+          }
+
+          return [...prevEntries, json].sort(
             (a, b) =>
               new Date(b.date || b.createdAt) -
               new Date(a.date || a.createdAt)
-          )
-        );
+          );
+        });
       })
       .catch((error) => {
         console.log(error);


### PR DESCRIPTION
Ensure the backend supports updating the entry for a date instead of creating duplicates.

Acceptance Criteria:

Creating/saving an entry for a date updates the existing entry if one already exists (or uses an upsert).
API supports fetching entry by date.